### PR TITLE
Fix test flakiness for cas provider

### DIFF
--- a/silhouette-cas/src/test/scala/play/silhouette/impl/providers/CasProviderSpec.scala
+++ b/silhouette-cas/src/test/scala/play/silhouette/impl/providers/CasProviderSpec.scala
@@ -97,7 +97,7 @@ class CasProviderSpec extends SocialProviderSpec[CasInfo] with Logger {
     "return a valid profile if the CAS client validates the ticket" in new Context {
       when(principal.getName).thenReturn(userName)
       when(principal.getAttributes).thenReturn(attr)
-      when(client.validateServiceTicket(ticket)).thenReturn(Future.successful(principal))
+      doReturn(Future.successful(principal)).when(client).validateServiceTicket(ticket)
 
       implicit val req: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/?ticket=%s".format(ticket))
 


### PR DESCRIPTION
## Fixes

Try to fix test flakiness:

```
[error]    If you're unsure why you're getting above error read on.
[error]    Due to the nature of the syntax above problem might occur because:
[error]    1. This exception *might* occur in wrongly written multi-threaded tests.
[error]       Please refer to Mockito FAQ on limitations of concurrency testing.
[error]    2. A spy is stubbed using when(spy.foo()).then() syntax. It is safer to stub spies - 
[error]       - with doReturn|Throw() family of methods. More in javadocs for Mockito.spy() method. (CasProviderSpec.scala:100)
[error] play.silhouette.impl.providers.CasProviderSpec$$anon$8.<init>(CasProviderSpec.scala:100)
```