### PR TITLE
Keep publishing artifacts with Java 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,4 +10,6 @@ jobs:
   publish-artifacts:
     name: Publish / Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v4
+    with:
+      java: 11
     secrets: inherit


### PR DESCRIPTION
Set Java 11 version explicitly to publish artefacts on CI.
