### PR TITLE
feat(jwt): support Authorization: Bearer header via configurable value parser (#230) 

### DIFF
--- a/silhouette/app/play/silhouette/api/util/ValueParser.scala
+++ b/silhouette/app/play/silhouette/api/util/ValueParser.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.silhouette.api.util
+
+trait ValueParser {
+
+  /**
+   * Parses a value from a field, be it headers, JSON body, etc.
+   *
+   * @param raw The raw value to parse
+   * @return The parsed value
+   */
+  def parseValue(raw: String): Option[String]
+}
+
+object DefaultValueParser extends ValueParser {
+
+  /**
+   * Parses a value from a field, be it headers, JSON body, etc. This is the default [[ValueParser]], and just returns the string as an option.
+   *
+   * @param raw The raw value to parse
+   * @return The parsed value
+   */
+  def parseValue(raw: String): Option[String] = Some(raw)
+
+}
+
+object BearerValueParser extends ValueParser {
+
+  /**
+   * Parses a value from a field, be it headers, JSON body, etc.
+   *
+   * @param raw The raw value to parse
+   * @return The parsed value
+   */
+  def parseValue(raw: String): Option[String] = {
+    if (raw.startsWith("Bearer ")) Some(raw.stripPrefix("Bearer ").trim) else None
+  }
+}

--- a/silhouette/test/play/silhouette/api/util/ValueParserSpec.scala
+++ b/silhouette/test/play/silhouette/api/util/ValueParserSpec.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.silhouette.api.util
+
+import org.specs2.mutable.Specification
+
+class ValueParserSpec extends Specification {
+
+  "DefaultValueParser" should {
+    "return the raw value wrapped in Some" in {
+      DefaultValueParser.parseValue("abc123") must beSome("abc123")
+    }
+  }
+
+  "BearerValueParser" should {
+    "return the token without Bearer prefix" in {
+      BearerValueParser.parseValue("Bearer abc123") must beSome("abc123")
+    }
+
+    "trim whitespace after Bearer prefix" in {
+      BearerValueParser.parseValue("Bearer     xyz789") must beSome("xyz789")
+    }
+
+    "return None if prefix is missing" in {
+      BearerValueParser.parseValue("xyz789") must beNone
+    }
+
+    "return None if input is just 'Bearer'" in {
+      BearerValueParser.parseValue("Bearer") must beNone
+    }
+
+    "return None if prefix is case-sensitive mismatch" in {
+      BearerValueParser.parseValue("bearer abc123") must beNone
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/playframework/play-silhouette/blob/main/CONTRIBUTING.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you suggest documentation edits?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #230

## Purpose

This PR introduces a new `valueParser` parameter to `JWTAuthenticatorSettings`, enabling support for the `Authorization: Bearer <token>` header format, as well as future token formats.

It provides:

* A `ValueParser` trait
* A default passthrough implementation (`DefaultValueParser`)
* A `BearerValueParser` implementation that extracts bearer tokens
* Integration into `JWTAuthenticatorService.retrieve(...)`

## Background Context

Silhouette currently supports extracting tokens via header, query string, and body field names — but does not support transforming those values. This is limiting for users who want to conform to industry standards like the `Authorization: Bearer` header used in OAuth2 and OpenID Connect.

Rather than introduce a new extraction abstraction, this PR builds on Silhouette’s existing `RequestExtractor` model by enabling post-processing of extracted values via a configurable `ValueParser`.

This approach is clean, minimal, and fully backward-compatible.

## References

* \#230
* Industry standard: [RFC 6750 - The OAuth 2.0 Authorization Framework: Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750)
* Real-world usage in `fetch`, `curl`, and many mobile SDKs

