### PR TITLE
Support Play 3.1.0-M1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,13 +23,13 @@ jobs:
     name: Binary Compatibility
     uses: playframework/.github/.github/workflows/binary-check.yml@v4
     with:
-      java: 11
+      java: 17
 
   check-docs:
     name: Docs
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 21, 17, 11
+      java: 21, 17
       scala: 2.13.x, 3.x
       cmd: sbt ++$MATRIX_SCALA doc
 
@@ -41,7 +41,7 @@ jobs:
       - "check-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 21, 17, 11
+      java: 21, 17
       scala: 2.13.x, 3.x
       cmd: >-
         sbt ++$MATRIX_SCALA test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,5 +11,5 @@ jobs:
     name: Publish / Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v4
     with:
-      java: 11
+      java: 17
     secrets: inherit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val commonsCodec = "commons-codec" % "commons-codec" % "1.18.0"
     val jbcrypt = "de.svenkubiak" % "jBCrypt" % "0.4.3"
     val jwt = "com.auth0" % "java-jwt" % "3.19.4"
-    val scalaGuice = "net.codingwell" %% "scala-guice" % "6.0.0"
+    val scalaGuice = "net.codingwell" %% "scala-guice" % "7.0.0"
     val pekkoTestkit = "org.apache.pekko" %% "pekko-testkit" % play.core.PlayVersion.pekkoVersion
     val mockito = "org.mockito" % "mockito-core" % "5.18.0"
     val casClient = "org.jasig.cas.client" % "cas-client-core" % "3.6.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin(dependency = "ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin(dependency = "com.github.sbt" % "sbt-unidoc" % "0.5.0")
-addSbtPlugin(dependency = "org.playframework" % "sbt-plugin" % "3.0.7")
+addSbtPlugin(dependency = "org.playframework" % "sbt-plugin" % "3.1.0-M1")
 addSbtPlugin(dependency = "com.github.sbt" % "sbt-ci-release" % "1.9.3")

--- a/silhouette-persistence/src/main/scala/play/silhouette/persistence/repositories/CacheAuthenticatorRepository.scala
+++ b/silhouette-persistence/src/main/scala/play/silhouette/persistence/repositories/CacheAuthenticatorRepository.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.persistence.repositories
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api.StorableAuthenticator
 import play.silhouette.api.repositories.AuthenticatorRepository

--- a/silhouette-testkit/test/play/silhouette/test/FakesSpec.scala
+++ b/silhouette-testkit/test/play/silhouette/test/FakesSpec.scala
@@ -17,7 +17,7 @@ package play.silhouette.test
 
 import com.google.inject.AbstractModule
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.silhouette.api.actions.{ SecuredRequest, UserAwareRequest }

--- a/silhouette-totp/src/main/scala/play/silhouette/impl/providers/GoogleTotpProvider.scala
+++ b/silhouette-totp/src/main/scala/play/silhouette/impl/providers/GoogleTotpProvider.scala
@@ -24,7 +24,7 @@ import play.silhouette.api.{ AuthInfo, LoginInfo, _ }
 import play.silhouette.impl.providers.GoogleTotpProvider._
 import play.silhouette.impl.providers.PasswordProvider._
 import com.warrenstrange.googleauth.{ GoogleAuthenticator, GoogleAuthenticatorQRGenerator }
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._

--- a/silhouette/app-2/play/silhouette/api/actions/SecuredAction.scala
+++ b/silhouette/app-2/play/silhouette/api/actions/SecuredAction.scala
@@ -19,7 +19,7 @@
  */
 package play.silhouette.api.actions
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.api.i18n.MessagesApi

--- a/silhouette/app-2/play/silhouette/api/actions/UserAwareAction.scala
+++ b/silhouette/app-2/play/silhouette/api/actions/UserAwareAction.scala
@@ -19,7 +19,7 @@
  */
 package play.silhouette.api.actions
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.api.{ Configuration, Environment => PlayEnv }

--- a/silhouette/app-3/play/silhouette/api/actions/SecuredAction.scala
+++ b/silhouette/app-3/play/silhouette/api/actions/SecuredAction.scala
@@ -19,7 +19,7 @@
  */
 package play.silhouette.api.actions
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.api.i18n.MessagesApi

--- a/silhouette/app-3/play/silhouette/api/actions/UserAwareAction.scala
+++ b/silhouette/app-3/play/silhouette/api/actions/UserAwareAction.scala
@@ -19,7 +19,7 @@
  */
 package play.silhouette.api.actions
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.api.{ Configuration, Environment => PlayEnv }

--- a/silhouette/app/play/silhouette/api/Silhouette.scala
+++ b/silhouette/app/play/silhouette/api/Silhouette.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.api
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api.actions._
 import play.api.mvc.AnyContent

--- a/silhouette/app/play/silhouette/api/actions/UnsecuredAction.scala
+++ b/silhouette/app/play/silhouette/api/actions/UnsecuredAction.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.api.actions
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.api.i18n.MessagesApi

--- a/silhouette/app/play/silhouette/api/crypto/AuthenticatorEncoder.scala
+++ b/silhouette/app/play/silhouette/api/crypto/AuthenticatorEncoder.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.api.crypto
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 /**
  * Specifies encoding/decoding of authenticator data.

--- a/silhouette/app/play/silhouette/impl/providers/BasicAuthProvider.scala
+++ b/silhouette/app/play/silhouette/impl/providers/BasicAuthProvider.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.impl.providers
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api.crypto.Base64
 import play.silhouette.api.exceptions.ConfigurationException

--- a/silhouette/app/play/silhouette/impl/providers/CredentialsProvider.scala
+++ b/silhouette/app/play/silhouette/impl/providers/CredentialsProvider.scala
@@ -19,7 +19,7 @@
  */
 package play.silhouette.impl.providers
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.silhouette.api.exceptions.ConfigurationException

--- a/silhouette/app/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
+++ b/silhouette/app/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.impl.providers.oauth1.secrets
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 import play.silhouette.api.Authenticator.Implicits._
 import play.silhouette.api.crypto.{ Crypter, Signer }
 import play.silhouette.api.util.{ Clock, ExtractableRequest }

--- a/silhouette/app/play/silhouette/impl/providers/state/CsrfStateItemHandler.scala
+++ b/silhouette/app/play/silhouette/impl/providers/state/CsrfStateItemHandler.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.impl.providers.state
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api.Logger
 import play.silhouette.api.crypto.Signer

--- a/silhouette/app/play/silhouette/impl/services/GravatarService.scala
+++ b/silhouette/app/play/silhouette/impl/services/GravatarService.scala
@@ -21,7 +21,7 @@ package play.silhouette.impl.services
 
 import java.net.URLEncoder._
 import java.security.MessageDigest
-import javax.inject.Inject
+import jakarta.inject.Inject
 import play.silhouette.api.Logger
 import play.silhouette.api.services.AvatarService
 import play.silhouette.api.util.{ ExecutionContextProvider, HTTPLayer }

--- a/silhouette/app/play/silhouette/impl/util/PlayCacheLayer.scala
+++ b/silhouette/app/play/silhouette/impl/util/PlayCacheLayer.scala
@@ -15,7 +15,7 @@
  */
 package play.silhouette.impl.util
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api.util.CacheLayer
 import play.api.cache.AsyncCacheApi

--- a/silhouette/test/play/silhouette/api/actions/SecuredActionSpec.scala
+++ b/silhouette/test/play/silhouette/api/actions/SecuredActionSpec.scala
@@ -17,7 +17,7 @@ package play.silhouette.api.actions
 
 import com.google.inject.AbstractModule
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import org.apache.pekko.actor.{ Actor, ActorSystem, Props }
 import org.apache.pekko.testkit.TestProbe

--- a/silhouette/test/play/silhouette/api/actions/UnsecuredActionSpec.scala
+++ b/silhouette/test/play/silhouette/api/actions/UnsecuredActionSpec.scala
@@ -17,7 +17,7 @@ package play.silhouette.api.actions
 
 import com.google.inject.AbstractModule
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import org.apache.pekko.actor.{ Actor, ActorSystem, Props }
 import org.apache.pekko.testkit.TestProbe

--- a/silhouette/test/play/silhouette/api/actions/UserAwareActionSpec.scala
+++ b/silhouette/test/play/silhouette/api/actions/UserAwareActionSpec.scala
@@ -17,7 +17,7 @@ package play.silhouette.api.actions
 
 import com.google.inject.AbstractModule
 
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 import play.silhouette.api._
 import play.silhouette.api.actions.UserAwareActionSpec._


### PR DESCRIPTION
## Purpose

Support Play! framework 3.1.0-M1 that has been released 5 months ago today.

**This version of Play! removes Java 11 support**

## Background Context

Play 3.1 supports latest guice and Pekko. Several libs have released version to support this M1 release. There is no indication when the final release will be ready.
