### PR TITLE
groupid + namespace change from `org.jasig` to `org.apereo`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,8 +43,8 @@ object Dependencies {
     val scalaGuice = "net.codingwell" %% "scala-guice" % "7.0.0"
     val pekkoTestkit = "org.apache.pekko" %% "pekko-testkit" % play.core.PlayVersion.pekkoVersion
     val mockito = "org.mockito" % "mockito-core" % "5.18.0"
-    val casClient = "org.jasig.cas.client" % "cas-client-core" % "3.6.4"
-    val casClientSupportSAML = "org.jasig.cas.client" % "cas-client-support-saml" % "3.6.4"
+    val casClient = "org.apereo.cas.client" % "cas-client-core" % "4.0.4"
+    val casClientSupportSAML = "org.apereo.cas.client" % "cas-client-support-saml" % "4.0.4"
     val apacheCommonLang = "org.apache.commons" % "commons-lang3" % "3.17.0"
     val googleAuth = "com.warrenstrange" % "googleauth" % "1.5.0"
     val izumiReflect = "dev.zio" %% "izumi-reflect" % "3.0.3" // Scala 3 replacement for scala 2 reflect universe

--- a/silhouette-cas/src/main/scala/play/silhouette/impl/providers/CasProvider.scala
+++ b/silhouette-cas/src/main/scala/play/silhouette/impl/providers/CasProvider.scala
@@ -25,9 +25,9 @@ import play.silhouette.impl
 import play.silhouette.impl.exceptions.ProfileRetrievalException
 import play.silhouette.impl.providers
 import play.silhouette.impl.providers.CasProvider._
-import org.jasig.cas.client.Protocol
-import org.jasig.cas.client.authentication.AttributePrincipal
-import org.jasig.cas.client.validation.{ AbstractUrlBasedTicketValidator, _ }
+import org.apereo.cas.client.Protocol
+import org.apereo.cas.client.authentication.AttributePrincipal
+import org.apereo.cas.client.validation.{ AbstractUrlBasedTicketValidator, _ }
 import play.api.mvc.{ Result, Results }
 
 import scala.concurrent.duration._

--- a/silhouette-cas/src/test/scala/play/silhouette/impl/providers/CasProviderSpec.scala
+++ b/silhouette-cas/src/test/scala/play/silhouette/impl/providers/CasProviderSpec.scala
@@ -19,7 +19,7 @@ import play.silhouette.api.exceptions.{ ConfigurationException, SilhouetteExcept
 import play.silhouette.api.util.HTTPLayer
 import play.silhouette.api.{ Logger, LoginInfo }
 
-import org.jasig.cas.client.authentication.AttributePrincipal
+import org.apereo.cas.client.authentication.AttributePrincipal
 import org.mockito.Mockito._
 import org.specs2.specification.Scope
 import play.api.mvc.AnyContentAsEmpty


### PR DESCRIPTION
* v3.6.4 README has old groupid: https://github.com/apereo/java-cas-client/tree/cas-client-3.6.4
* v4.0.0 README has new groupid: https://github.com/apereo/java-cas-client/tree/v4.0.0
* groupid/namespace change in this commit: https://github.com/apereo/java-cas-client/commit/496adb1cf6bcc4ec55e7911c5eb5b75b5325bdf6
* They talk about it here as well: https://github.com/apereo/java-cas-client/pull/736

Found out because I was looking at the vulnavulnerabilities